### PR TITLE
PHP 8.4 - Fixes for implicit nullability deprecation

### DIFF
--- a/src/MongoDBInstrumentation.php
+++ b/src/MongoDBInstrumentation.php
@@ -14,7 +14,7 @@ final class MongoDBInstrumentation
     /**
      * @param callable(object):?string $commandSerializer
      */
-    public static function register(callable $commandSerializer = null): void
+    public static function register(?callable $commandSerializer = null): void
     {
         $instrumentation = new CachedInstrumentation(
             'io.opentelemetry.contrib.php.mongodb',


### PR DESCRIPTION
Error running on PHP 8.4:

```
OpenTelemetry\Contrib\Instrumentation\MongoDB\MongoDBInstrumentation::register(): Implicitly marking parameter $commandSerializer as nullable is deprecated, the explicit nullable type must be used instead
```

Fixes all issues that emit deprecation notices on PHP 8.4 for implicit nullable parameter type declarations. This requires PHP 7.1 (we currently require PHP >=7.4), so we are safe
 
See:
 
* [RFC](https://wiki.php.net/rfc/deprecate-implicitly-nullable-types)
* [PHP 8.4: Implicitly nullable parameter declarations deprecated](https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated)

